### PR TITLE
Bugfix: Label tags text can't distinguish

### DIFF
--- a/miniprogram/components/tag/index.js
+++ b/miniprogram/components/tag/index.js
@@ -32,8 +32,47 @@ VantComponent({
       var style = key + ": " + color;
       if (this.data.textColor) {
         style += "; color: " + this.data.textColor
+      } else {
+        // no text color case
+        var textColor = this.generateTextColor(this.data.color)
+        if (textColor !== null) {
+          style += "; color: " + textColor
+        }
       }
       return style;
+    }
+  },
+  // methods
+  methods: {
+    generateTextColor(color) {
+      if (color === null ||
+        color === undefined ||
+        color.indexOf("#") !== 0) {
+        return null
+      }
+      var r, g, b
+      if (color.length == 4) {
+        // eg:#fff
+        var rText = color.substr(1, 1)
+        var gText = color.substr(2, 1)
+        var bText = color.substr(3, 1)
+        r = parseInt(`${rText}${rText}`, 16)
+        g = parseInt(`${gText}${gText}`, 16)
+        b = parseInt(`${bText}${bText}`, 16)
+      } else if (color.length == 7) {
+        // eg: #ffffff
+        r = parseInt(`${color.substr(1, 2)}`, 16)
+        g = parseInt(`${color.substr(3, 2)}`, 16)
+        b = parseInt(`${color.substr(5, 2)}`, 16)
+      }
+      if (r !== undefined && g !== undefined && b !== undefined) {
+        if (r >= 153 && g >= 110 && b > 10) {
+          return '#000'
+        } else {
+          return '#fff'
+        }
+      }
+      return null
     }
   }
 });

--- a/miniprogram/pages/issue-detail/issue-detail.wxml
+++ b/miniprogram/pages/issue-detail/issue-detail.wxml
@@ -33,6 +33,6 @@
 </view>
 <popup show="{{ editLabels }}" position="bottom" bind:close="onClose" custom-class='labels-popup'>
   <v-checkbox custom-class='v-checkbox' wx:for='{{allLabels}}' wx:key="index" value='{{ item.selected }}' checked-color='#000' bind:change="onLabelChanged" data-tag='{{item}}'>
-    <tag color='#{{item.color}}' class='tag' size='large' text-color='{{ item.textColor }}'>{{ item.name }}</tag>
+    <tag color='#{{item.color}}' class='tag' size='large'>{{ item.name }}</tag>
   </v-checkbox>
 </popup>


### PR DESCRIPTION
Fixes #31 

# 背景
如31问题所示，在Label tags白色背景的情况下，文本颜色也是白色，所以导致无法看出tag内容是什么。
我通过修复 tag 组件内部方法，在外部没有指定Label tag 的 TextColor 的情况下，通过自动算法，来设置 
TextColor 修复此问题。

# 实现原理
通过观察Github网页版的 Tags 标签样式，猜测文本颜色算法大致为：R大于等于153，G大于等于110，B大于10的情况下）文本的 TextColor 为黑色，反之为白色。

# 效果对比
修改后与 Github 官网效果对比（并且随机添加3个 Label 测试）

Mini-Github：
![image](https://user-images.githubusercontent.com/3383471/57580006-13c55180-74d7-11e9-9134-f33e26488df8.png)

Github：
![image](https://user-images.githubusercontent.com/3383471/57580020-30618980-74d7-11e9-8ce2-e2759dc99e3b.png)


# 测试
目前我们 Label Tag  #的使用场景目前我们有一下几个场景，一一验证确认修复此问题。

issues首页：
![image](https://user-images.githubusercontent.com/3383471/57580001-03ad7200-74d7-11e9-8071-201b23bbee56.png)

issues 详情页：
![image](https://user-images.githubusercontent.com/3383471/57580057-74ed2500-74d7-11e9-85d0-f8bcbbdddc3e.png)

repo详情页：
![image](https://user-images.githubusercontent.com/3383471/57580059-820a1400-74d7-11e9-95ae-59643d0c224a.png)

PR 页面：
![image](https://user-images.githubusercontent.com/3383471/57580065-9221f380-74d7-11e9-96a0-c5bbfb2fce76.png)

Label 设置页面：
![image](https://user-images.githubusercontent.com/3383471/57580069-9cdc8880-74d7-11e9-827c-a76aa2606fcd.png)

多主题测试（Light 主题测试）
![image](https://user-images.githubusercontent.com/3383471/57580082-af56c200-74d7-11e9-95f0-aa6cfdc2bd3d.png)

多主题测试（Dark 主题测试）
![image](https://user-images.githubusercontent.com/3383471/57580091-c1386500-74d7-11e9-8d6e-4acca2018cdd.png)